### PR TITLE
remove 'Location' parameter when it's not needed

### DIFF
--- a/ForTheCommonGood/en.wikipedia.wiki
+++ b/ForTheCommonGood/en.wikipedia.wiki
@@ -80,6 +80,10 @@ IfContains={{split media
 Message=The file is tagged with {{split media}}. Click "Select version..." above to view earlier versions;  you may need to transfer each one separately.
 
 [Replacement]
+LookFor=\| *Location *= *\n*(\||\}\})
+ReplaceWith=$1
+
+[Replacement]
 LookFor={{orphan image.*}}\n?
 ReplaceWith=
 

--- a/ForTheCommonGood/en.wikipedia.wiki
+++ b/ForTheCommonGood/en.wikipedia.wiki
@@ -10,8 +10,8 @@ LocalFtcgPage=w:en:WP:FTCG
 
 Category1=Copy to Wikimedia Commons
 Category2=Copy to Wikimedia Commons (bot-assessed)
-Category3=Move to Commons Priority Candidates
-DefaultCategory=3
+Category3=
+DefaultCategory=1
 
 Information=Information
 Description=Description
@@ -90,6 +90,10 @@ ReplaceWith=
 [Replacement]
 LookFor={{needs commons category}}
 ReplaceWith=
+
+[Replacement]
+LookFor={{Convert to SVG and copy to Wikimedia Commons}}
+ReplaceWith={{SVG}}
 
 [Replacement]
 LookFor={{(bots|nobots|Wikipedia:Bots/Status/template)[^\}]*}}


### PR DESCRIPTION
Remove 'Location' parameter when found *and* it has no value. On Commons it's not recognized and generates a "Error in template * unknown parameter name (Template:Information): 'Location'"